### PR TITLE
Inline queue-tick dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var queueTick = require('queue-tick')
-
 exports.fromCallback = function (callback, symbol) {
   if (callback === undefined) {
     var promise = new Promise(function (resolve, reject) {
@@ -25,4 +23,16 @@ exports.fromPromise = function (promise, callback) {
   promise
     .then(function (res) { queueTick(() => callback(null, res)) })
     .catch(function (err) { queueTick(() => callback(err)) })
+}
+
+function queueTick (cb) {
+  if (typeof process !== 'undefined' &&
+      typeof process.nextTick === 'function'
+  ) {
+    process.nextTick(cb)
+  } else if (typeof queueMicrotask === 'function') {
+    queueMicrotask(cb)
+  } else {
+    Promise.resolve().then(cb)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "author": "Vincent Weevers",
   "scripts": {
-    "test": "standard && node test.js"
+    "test": "standard && node test.js",
+    "test:browser": "browserify test.js | tape-run"
   },
   "types": "index.d.ts",
   "files": [
@@ -16,8 +17,10 @@
     "queue-tick": "^1.0.0"
   },
   "devDependencies": {
+    "browserify": "17.0.0",
     "standard": "^14.0.0",
-    "tape": "^5.0.0"
+    "tape": "^5.0.0",
+    "tape-run": "9.0.0"
   },
   "keywords": [
     "callback",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "index.js",
     "index.d.ts"
   ],
-  "dependencies": {
-    "queue-tick": "^1.0.0"
-  },
   "devDependencies": {
     "browserify": "17.0.0",
     "standard": "^14.0.0",


### PR DESCRIPTION
This removes the queue-tick dependency, adds an inline
implementation and adds a `test:browser` command to
verify the implementation works in the browser.